### PR TITLE
Separate config for development and production builds

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,7 +17,7 @@
 		{
 			"label": "webpackBuild",
 			"type": "npm",
-			"script": "webpack-dev",
+			"script": "webpack:watch",
 			"problemMatcher": {
 				"base": "$tsc-watch",
 				"background": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-	"name": "tmc-vscode",
-	"version": "0.0.1",
+	"name": "test-my-code",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -5476,6 +5476,15 @@
 						"yargs-parser": "^13.1.0"
 					}
 				}
+			}
+		},
+		"webpack-merge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+			"integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.15"
 			}
 		},
 		"webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -81,15 +81,15 @@
 		}
 	},
 	"scripts": {
-		"vscode:prepublish": "webpack --mode production",
+		"vscode:prepublish": "webpack --config webpack.prod.js",
 		"compile": "ttsc -p ./",
 		"watch": "ttsc -watch -p ./",
 		"pretest": "npm run compile",
 		"test": "node ./out/test/runTest.js",
 		"tslint": "tslint --project .",
 		"postinstall": "babel node_modules/ts-results --out-dir node_modules/ts-results --plugins=@babel/plugin-transform-modules-commonjs",
-		"webpack": "webpack --mode development",
-		"webpack-dev": "webpack --mode development --watch --info-verbosity verbose"
+		"webpack": "webpack --config webpack.dev.js",
+		"webpack:watch": "webpack --config webpack.dev.js --watch --info-verbosity verbose"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.8.3",
@@ -109,7 +109,8 @@
 		"typescript": "^3.6.4",
 		"vscode-test": "^1.2.2",
 		"webpack": "^4.41.6",
-		"webpack-cli": "^3.3.11"
+		"webpack-cli": "^3.3.11",
+		"webpack-merge": "^4.2.2"
 	},
 	"dependencies": {
 		"client-oauth2": "^4.2.5",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,11 +7,11 @@ import WorkspaceManager from "./api/workspaceManager";
 import Storage from "./config/storage";
 import { UserData } from "./config/userdata";
 import UI from "./ui/ui";
-import { getCurrentExerciseId } from "./utils";
+import { getCurrentExerciseId, isProductionBuild } from "./utils";
 
 export async function activate(context: vscode.ExtensionContext) {
-
-    console.log('Congratulations, your extension "tmc-vscode" is now active!');
+    const productionMode = isProductionBuild();
+    console.log(`Starting extension in ${productionMode ? "production" : "development"} mode.`);
 
     const result = await init.firstTimeInitialization(context);
     if (result.ok) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 
 import { Err, Ok, Result } from "ts-results";
+import { is } from "typescript-is";
 import WorkspaceManager from "./api/workspaceManager";
 import { ConnectionError } from "./errors";
 /**
@@ -78,6 +79,26 @@ export async function downloadFile(url: string, filePath: string,
     }
 
     return Ok.EMPTY;
+}
+
+/**
+ * Checks whether the extension is running in a development or production environment.
+ */
+export function isProductionBuild(): boolean {
+    // Use configuration properties to see whether superflous object properties are enabled in tsconfig.
+    // In the code this feature is used when fetched API data is being parsed.
+    // For configuration, see tsconfig.json used by webpack.dev.json
+    // and tsconfig.production.json used by webpack.prod.json
+    type TestType = {
+        strict: boolean,
+    };
+
+    const testObject = {
+        strict: true,
+        superflous: "a superfluous property",
+    };
+
+    return is<TestType>(testObject);
 }
 
 /**

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -1,0 +1,13 @@
+{
+    // Extended tsconfig properties for production
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "plugins": [
+            {
+                "transform": "typescript-is/lib/transform-inline/transformer",
+                // Don't break when TMC API is extended
+                "disallowSuperfluousObjectProperties": false
+            }
+        ]
+    }
+}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -15,7 +15,6 @@ const config = {
         libraryTarget: 'commonjs2',
         devtoolModuleFilenameTemplate: '../[resource-path]'
     },
-    devtool: 'source-map',
     externals: {
         vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     },
@@ -25,22 +24,7 @@ const config = {
         alias: {
             handlebars: 'handlebars/dist/handlebars.min.js'
         }
-    },
-    module: {
-        rules: [
-            {
-                test: /\.ts$/,
-                exclude: /node_modules/,
-                use: [
-                    {
-                        loader: 'ts-loader',
-                        options: {
-                            compiler: 'ttypescript'
-                        }
-                    }
-                ]
-            }
-        ]
     }
 };
+
 module.exports = config;

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,31 @@
+//@ts-check
+
+'use strict';
+
+const merge = require('webpack-merge');
+const common = require('./webpack.common');
+
+/**@type {import('webpack').Configuration}*/
+const devConfig = {
+    mode: 'development',
+    devtool: 'inline-source-map',
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'ts-loader',
+                        options: {
+                            compiler: 'ttypescript',
+                            configFile: 'tsconfig.json'
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}
+
+module.exports = merge(common, devConfig);

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,30 @@
+//@ts-check
+
+'use strict';
+
+const merge = require('webpack-merge');
+const common = require('./webpack.common');
+
+/**@type {import('webpack').Configuration}*/
+const devConfig = {
+    mode: 'production',
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'ts-loader',
+                        options: {
+                            compiler: 'ttypescript',
+                            configFile: 'tsconfig.production.json' // Use extended tsconfig settings for production
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}
+
+module.exports = merge(common, devConfig);


### PR DESCRIPTION
Resolves #210 
Superfluous object properties for `ttypescript` are now allowed if and only if using a production build.