### PR TITLE
Remove button for courses

### DIFF
--- a/resources/templates/index.html
+++ b/resources/templates/index.html
@@ -16,6 +16,9 @@
         {{#each courses}}
         <div class="row org-row border-dark">
             <div class="col-md" onclick="fetchCourseDetails({{this.id}})">
+                <button type="button" class="close"  onclick="removeCourse(event, {{this.id}})" aria-label="Remove course">
+                    <span aria-hidden="true">&times;</span>
+                </button>
                 <h3>{{this.name}} <small class="text-muted">{{this.organization}}</small></h3>
                 <p>{{this.description}}</p>
             </div>
@@ -35,6 +38,12 @@
         function addCourse() {
             vscode.postMessage({ type: "addCourse" });
         }
+
+        function removeCourse(event, id) {
+            event.stopPropagation(); // Don't send onclick event upwards
+            vscode.postMessage({ type: "removeCourse", id });
+        }
+
         function fetchCourseDetails(id) {
             vscode.postMessage({ type: "courseDetails", id: id });
         }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -321,6 +321,17 @@ export async function selectCourse(orgSlug: string, { tmc, resources, ui }: Acti
 }
 
 /**
+ * Removes given course from UserData and closes all its exercises.
+ * @param id ID of the course to remove
+ */
+export async function removeCourse(id: number, actionContext: ActionContext) {
+    const course = actionContext.userData.getCourse(id);
+    await closeExercises(course.exercises.map((e) => e.id), actionContext);
+    actionContext.userData.deleteCourse(id);
+    vscode.window.showInformationMessage(`${course.name} was removed from courses.`);
+}
+
+/**
  * Lets the user select an organization
  */
 export async function selectOrganization({ resources, tmc, ui }: ActionContext, webview?: TemporaryWebview):

--- a/src/init.ts
+++ b/src/init.ts
@@ -7,13 +7,13 @@ import UI from "./ui/ui";
 import { Err, Ok, Result } from "ts-results";
 import {
     closeCompletedExercises, closeExercises, displayCourseDownloadDetails, displayLocalExerciseDetails, displaySummary,
-    downloadExercises, login, logout, openExercises, openUncompletedExercises, selectNewCourse,
+    downloadExercises, login, logout, openExercises, openUncompletedExercises, removeCourse, selectNewCourse,
 } from "./actions/actions";
 import WorkspaceManager from "./api/workspaceManager";
 import Resources from "./config/resources";
 import Storage from "./config/storage";
 import { UserData } from "./config/userdata";
-import { downloadFileWithProgress, isJavaPresent } from "./utils";
+import { askForConfirmation, downloadFileWithProgress, isJavaPresent } from "./utils";
 
 /**
  * Registers the various actions and handlers required for the user interface to function.
@@ -59,6 +59,13 @@ export function registerUiActions(
     });
     ui.webview.registerHandler("addCourse", () => {
         selectNewCourse(actionContext);
+    });
+    ui.webview.registerHandler("removeCourse", async (msg: { type: "removeCourse", id: number }) => {
+        const course = actionContext.userData.getCourse(msg.id);
+        if (await askForConfirmation(`Do you want to remove ${course.name} from your courses? This won't delete your downloaded exercises.`)) {
+            await removeCourse(msg.id, actionContext);
+            displaySummary(actionContext);
+        }
     });
     ui.webview.registerHandler("exerciseDownloads", (msg: { type: string, id: number }) => {
         displayCourseDownloadDetails(msg.id, actionContext);


### PR DESCRIPTION
Fixes #194 

Added a close button for each course. Pressing them will ask for a confirmation to close all given course's open exercises and remove that course from the list. Closed exercises won't be deleted, so adding the course back will display them again.