### PR TITLE
automate webview build on extension launch in development

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-            "preLaunchTask": "webpackBuild",
+            "preLaunchTask": "buildAll",
             "sourceMaps": true
         },
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,6 +30,26 @@
             "runOptions": {
                 "instanceLimit": 1
             }
+        },
+        {
+            "label": "webviewBuild",
+            "type": "npm",
+            "script": "webview:build",
+            "problemMatcher": [],
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": true
+            }
+        },
+        {
+            "label": "buildAll",
+            "dependsOrder": "sequence",
+            "dependsOn": ["webviewBuild", "webpackBuild"],
+            "problemMatcher": []
         }
     ],
     "inputs": [


### PR DESCRIPTION
Currently, launching the extension in the _Extension Development Host_ results in a blank screen. This was because of missing Svelte UI compilation step. 
Added two new tasks in `tasks.json`, and linked it to `launch.json` 
Now the pages aren't blank anymore on locally running after intial setups. 